### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/aswalia/voronoi/security/code-scanning/1](https://github.com/aswalia/voronoi/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege token access unless overridden.  
For this workflow, the best minimal fix is:

```yml
permissions:
  contents: read
```

This preserves existing functionality (checkout/build/test) while constraining token scope.  
Edit `.github/workflows/ci-cd.yml` near the top-level keys (after `on:` block and before `jobs:` is clean and conventional). No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
